### PR TITLE
Typst-to-div: inline support + specifiable prefixes

### DIFF
--- a/typst-to-div/_extensions/typst-to-div/typst-to-div.lua
+++ b/typst-to-div/_extensions/typst-to-div/typst-to-div.lua
@@ -38,14 +38,9 @@ end
 -- helps pandoc convert quarto divs to typst blocks
 function convertDiv(el)
 
-  quarto.log.output("checking block" .. tostring(el.classes) ..
-    " against " .. typst_block_prefix)
-
   -- if block prefix is found in the classes for the content div, it is
   -- wrapped in a raw typst block using the corresponding style
   if string.match(tostring(el.classes) .. "-", typst_block_prefix) then
-
-    quarto.log.output("FOUND BLOCK")
 
     divName = string.match(
       tostring(el.classes),
@@ -63,14 +58,9 @@ end
 -- helps pandoc convert quarto spans to typst inlines
 function convertInline(el)
 
-  quarto.log.output("checking inline: " .. tostring(el.classes) ..
-    " against " .. typst_inline_prefix)
-
   -- if block prefix is found in the classes for the content div, it is
   -- wrapped in a raw typst block using the corresponding style
   if string.match(tostring(el.classes) .. "-", typst_inline_prefix) then
-
-    quarto.log.output("FOUND INLINE")
 
     inlineName = string.match(
       tostring(el.classes),

--- a/typst-to-div/_extensions/typst-to-div/typst-to-div.lua
+++ b/typst-to-div/_extensions/typst-to-div/typst-to-div.lua
@@ -19,28 +19,37 @@ local function endTypstBlock(blocks)
   end
 end
 
--- detects project name as the parent directory to _extensions
-local function getProjectName(path)
-
-  pattern1 = ".*//(.*)//_extensions//"
-  pattern2 = ".*\\(.*)\\_extensions\\"
-
-  if (string.match(path, pattern1) == nil) then
-    return string.match(path, pattern2)
+-- gets options for preferred prefixes from the document meta, or falls back
+-- if not specified
+function readMeta(m)
+  if m["typst-block-prefix"] ~= nil then
+    typst_block_prefix = pandoc.utils.stringify(m["typst-block-prefix"])
   else
-    return string.match(path, pattern1)
+    typst_block_prefix = "typst-block"
   end
 
+  if m["typst-inline-prefix"] ~= nil then
+    typst_inline_prefix = pandoc.utils.stringify(m["typst-inline-prefix"])
+  else
+    typst_inline_prefix = "typst-inline"
+  end
 end
 
 -- helps pandoc convert quarto divs to typst blocks
-function Div(el)
+function convertDiv(el)
 
-  project = string.gsub(getProjectName(PANDOC_SCRIPT_FILE), "%-", "%%-")
+  quarto.log.output("checking block" .. tostring(el.classes) ..
+    " against " .. typst_block_prefix)
 
-  if string.match(tostring(el.classes), project) then
+  -- if block prefix is found in the classes for the content div, it is
+  -- wrapped in a raw typst block using the corresponding style
+  if string.match(tostring(el.classes) .. "-", typst_block_prefix) then
 
-    divName = string.match(tostring(el.classes), project .. "%-(.*)%}")
+    quarto.log.output("FOUND BLOCK")
+
+    divName = string.match(
+      tostring(el.classes),
+      typst_block_prefix .. "%-(.*)%}")
     local blocks = pandoc.List({
       pandoc.RawBlock('typst', '#' .. divName .. '[')
     })
@@ -51,3 +60,39 @@ function Div(el)
 
 end
 
+-- helps pandoc convert quarto spans to typst inlines
+function convertInline(el)
+
+  quarto.log.output("checking inline: " .. tostring(el.classes) ..
+    " against " .. typst_inline_prefix)
+
+  -- if block prefix is found in the classes for the content div, it is
+  -- wrapped in a raw typst block using the corresponding style
+  if string.match(tostring(el.classes) .. "-", typst_inline_prefix) then
+
+    quarto.log.output("FOUND INLINE")
+
+    inlineName = string.match(
+      tostring(el.classes),
+      typst_inline_prefix .. "%-(.*)%}")
+    local inlines = pandoc.List({
+      pandoc.RawInline('typst', '#' .. inlineName .. '[')
+    })
+
+    el.content:insert(pandoc.RawInline('typst', ']'))
+    inlines:extend(el.content)
+    return inlines
+
+  end
+
+end
+
+return {
+  {
+    Meta = readMeta
+  },
+  {
+    Div = convertDiv,
+    Span = convertInline
+  }
+}


### PR DESCRIPTION
Thanks for the great `typst-to-div` filter, @cl-roberts! I found it really useful. I made a few modifications and wanted to see if you were interested in merging them back up (happy to also provide them as separate PRs if you'd rather pick and choose).

The highlights are:

- Div/span prefix specified in meta with defaults if not specified
  - (This also fixes #1, as the project name isn't used at all)
- Support for inline styles as well as blocks

Thanks again!
